### PR TITLE
Patch Mesos Dispatcher to more correctly handle auxilliary JARs.

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
@@ -409,6 +409,9 @@ private[spark] class MesosClusterScheduler(
     desc.schedulerProperties.get("spark.mesos.uris").map { uris =>
       setupUris(uris, builder)
     }
+    desc.schedulerProperties.get("spark.jars").map { uris =>
+      setupUris(uris, builder)
+    }
     desc.schedulerProperties.get("spark.submit.pyFiles").map { pyFiles =>
       setupUris(pyFiles, builder)
     }
@@ -421,6 +424,12 @@ private[spark] class MesosClusterScheduler(
       "--master", s"mesos://${conf.get("spark.master")}",
       "--driver-cores", desc.cores.toString,
       "--driver-memory", s"${desc.mem}M")
+
+    if (desc.schedulerProperties.get("spark.jars").isDefined) {
+      val jarFiles = desc.schedulerProperties.get("spark.jars").get
+        .split(",").map(uri => uri.substring(uri.lastIndexOf('/') + 1)).mkString(",")
+      options ++= Seq("--jars", jarFiles)
+    }
 
     val replicatedOptionsBlacklist = Set(
       "spark.jars", // Avoids duplicate classes in classpath

--- a/pom.xml
+++ b/pom.xml
@@ -1953,7 +1953,7 @@
           <configuration>
             <scalaVersion>${scala.version}</scalaVersion>
             <recompileMode>incremental</recompileMode>
-            <useZincServer>true</useZincServer>
+            <!--useZincServer>true</useZincServer-->
             <args>
               <arg>-unchecked</arg>
               <arg>-deprecation</arg>


### PR DESCRIPTION
## What changes were proposed in this pull request?

For JARs passed to `spark-submit` using `--jars`, download them all to the driver working dir and use `--jars` to tell the driver `spark-submit` about them.
## How was this patch tested?

Manually tested by standing up a Procurify instance and running ingest and pair generation. This will soon be tested in automation once we get minimesos and Mesos integration tests working.
